### PR TITLE
fix: relax beat health check for optional data sources

### DIFF
--- a/apps/api_router/health_views.py
+++ b/apps/api_router/health_views.py
@@ -12,6 +12,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+OPTIONAL_DATA_SOURCES = {'cmc_market_data', 'kline_data'}
+
 def _check_data_freshness():
     """
     检查关键数据的新鲜度
@@ -23,21 +25,29 @@ def _check_data_freshness():
         from django.utils import timezone
         now = timezone.now()
         
-        # 检查CMC市场数据新鲜度
-        try:
-            from apps.cmc_proxy.models import CmcMarketData
-            latest_market_data = CmcMarketData.objects.order_by('-updated_at').first()
-            if latest_market_data:
-                age_seconds = (now - latest_market_data.updated_at).total_seconds()
-                freshness_status['cmc_market_data'] = {
-                    'last_update': latest_market_data.updated_at.isoformat(),
-                    'age_seconds': int(age_seconds),
-                    'status': 'fresh' if age_seconds < 600 else 'stale'  # 10分钟阈值
-                }
-            else:
-                freshness_status['cmc_market_data'] = {'status': 'no_data'}
-        except Exception as e:
-            freshness_status['cmc_market_data'] = {'status': 'error', 'error': str(e)}
+        cmc_features_enabled = getattr(settings, 'CMC_FEATURES_ENABLED', False)
+        
+        if cmc_features_enabled:
+            # 检查CMC市场数据新鲜度
+            try:
+                from apps.cmc_proxy.models import CmcMarketData
+                latest_market_data = CmcMarketData.objects.order_by('-updated_at').first()
+                if latest_market_data:
+                    age_seconds = (now - latest_market_data.updated_at).total_seconds()
+                    freshness_status['cmc_market_data'] = {
+                        'last_update': latest_market_data.updated_at.isoformat(),
+                        'age_seconds': int(age_seconds),
+                        'status': 'fresh' if age_seconds < 600 else 'stale'  # 10分钟阈值
+                    }
+                else:
+                    freshness_status['cmc_market_data'] = {'status': 'no_data'}
+            except Exception as e:
+                freshness_status['cmc_market_data'] = {'status': 'error', 'error': str(e)}
+        else:
+            freshness_status['cmc_market_data'] = {
+                'status': 'disabled',
+                'message': 'CMC 市场数据采集已暂停'
+            }
         
         # 检查价格 Oracle 数据新鲜度
         try:
@@ -55,21 +65,27 @@ def _check_data_freshness():
         except Exception as e:
             freshness_status['price_oracle'] = {'status': 'error', 'error': str(e)}
         
-        # 检查K线数据新鲜度
-        try:
-            from apps.cmc_proxy.models import CmcKline
-            latest_kline = CmcKline.objects.filter(timeframe='1h').order_by('-timestamp').first()
-            if latest_kline:
-                age_seconds = (now - latest_kline.timestamp).total_seconds()
-                freshness_status['kline_data'] = {
-                    'last_update': latest_kline.timestamp.isoformat(),
-                    'age_seconds': int(age_seconds),
-                    'status': 'fresh' if age_seconds < 7200 else 'stale'  # 2小时阈值
-                }
-            else:
-                freshness_status['kline_data'] = {'status': 'no_data'}
-        except Exception as e:
-            freshness_status['kline_data'] = {'status': 'error', 'error': str(e)}
+        if cmc_features_enabled:
+            # 检查K线数据新鲜度
+            try:
+                from apps.cmc_proxy.models import CmcKline
+                latest_kline = CmcKline.objects.filter(timeframe='1h').order_by('-timestamp').first()
+                if latest_kline:
+                    age_seconds = (now - latest_kline.timestamp).total_seconds()
+                    freshness_status['kline_data'] = {
+                        'last_update': latest_kline.timestamp.isoformat(),
+                        'age_seconds': int(age_seconds),
+                        'status': 'fresh' if age_seconds < 7200 else 'stale'  # 2小时阈值
+                    }
+                else:
+                    freshness_status['kline_data'] = {'status': 'no_data'}
+            except Exception as e:
+                freshness_status['kline_data'] = {'status': 'error', 'error': str(e)}
+        else:
+            freshness_status['kline_data'] = {
+                'status': 'disabled',
+                'message': 'CMC K线采集已暂停'
+            }
             
     except Exception as e:
         freshness_status['error'] = str(e)
@@ -209,6 +225,15 @@ def _is_valid_cmc_key(api_key: str) -> bool:
 
 def _check_cmc_keys_health():
     """检查CMC API Keys的配置状态"""
+    cmc_features_enabled = getattr(settings, 'CMC_FEATURES_ENABLED', False)
+    
+    if not cmc_features_enabled:
+        return {
+            'status': 'disabled',
+            'message': 'CMC 相关功能已暂停',
+            'warning': False
+        }
+    
     cmc_keys_status = {}
     
     try:
@@ -346,9 +371,14 @@ def beat_health(request):
         }
         
         # 根据数据新鲜度和CMC Keys状态调整整体状态
+        optional_sources = OPTIONAL_DATA_SOURCES
         if overall_status == 'healthy':
-            stale_data_count = sum(1 for status in data_freshness.values() 
-                                 if isinstance(status, dict) and status.get('status') == 'stale')
+            stale_data_count = sum(
+                1 for name, status in data_freshness.items()
+                if name not in optional_sources
+                and isinstance(status, dict)
+                and status.get('status') == 'stale'
+            )
             
             # 检查CMC Keys是否有警告
             cmc_keys_warning = cmc_keys_status.get('warning', False)
@@ -357,7 +387,7 @@ def beat_health(request):
                 overall_status = 'warning'
         
         response_data['status'] = overall_status
-        status_code = 200 if overall_status == 'healthy' else 503
+        status_code = 200 if overall_status in ['healthy', 'warning'] else 503
         return JsonResponse(response_data, status=status_code)
         
     except Exception as e:

--- a/scripts/k3s/monitor_beat_health.sh
+++ b/scripts/k3s/monitor_beat_health.sh
@@ -104,18 +104,24 @@ check_critical_tasks() {
 check_data_freshness() {
     if [[ -f "/tmp/beat_health.json" ]]; then
         # 检查各类数据的新鲜度
-        local stale_count=$(jq -r '.data_freshness | to_entries[] | select(.value.status == "stale") | .key' /tmp/beat_health.json 2>/dev/null | wc -l)
-        local no_data_count=$(jq -r '.data_freshness | to_entries[] | select(.value.status == "no_data") | .key' /tmp/beat_health.json 2>/dev/null | wc -l)
+        local stale_optional_count=$(jq '[.data_freshness | to_entries[] | select((.key == "cmc_market_data" or .key == "kline_data") and .value.status == "stale")] | length' /tmp/beat_health.json 2>/dev/null || echo 0)
+        local stale_non_optional_count=$(jq '[.data_freshness | to_entries[] | select((.key != "cmc_market_data" and .key != "kline_data") and .value.status == "stale")] | length' /tmp/beat_health.json 2>/dev/null || echo 0)
+        local stale_optional_names=$(jq -r '.data_freshness | to_entries[] | select((.key == "cmc_market_data" or .key == "kline_data") and .value.status == "stale") | .key' /tmp/beat_health.json 2>/dev/null | tr '\n' ' ')
+        local stale_non_optional_names=$(jq -r '.data_freshness | to_entries[] | select((.key != "cmc_market_data" and .key != "kline_data") and .value.status == "stale") | .key' /tmp/beat_health.json 2>/dev/null | tr '\n' ' ')
+        local no_data_count=$(jq '[.data_freshness | to_entries[] | select(.value.status == "no_data")] | length' /tmp/beat_health.json 2>/dev/null || echo 0)
         
-        if [[ $stale_count -eq 0 && $no_data_count -eq 0 ]]; then
+        if [[ $stale_optional_count -eq 0 && $stale_non_optional_count -eq 0 && $no_data_count -eq 0 ]]; then
             log "✅ 所有数据源都是新鲜的"
             return 0
         elif [[ $no_data_count -gt 0 ]]; then
             error "❌ 发现无数据的数据源，任务可能从未执行成功"
             return 1
-        else
-            warn "⚠️  发现 $stale_count 个数据源过期，任务可能执行缓慢或失败"
+        elif [[ $stale_non_optional_count -gt 0 ]]; then
+            error "❌ 核心数据源过期: $stale_non_optional_names"
             return 1
+        else
+            warn "⚠️  可选数据源过期: $stale_optional_names"
+            return 0
         fi
     else
         warn "无法获取数据新鲜度信息"
@@ -159,8 +165,20 @@ check_api_health() {
                 log "✅ Beat API健康检查通过"
                 return 0
             elif [[ "$api_status" == "warning" ]]; then
-                warn "⚠️  Beat API状态警告，可能有数据延迟: $stale_data"
-                return 1
+                local critical_stale=""
+                for source in $stale_data; do
+                    if [[ -n "$source" && "$source" != "cmc_market_data" && "$source" != "kline_data" ]]; then
+                        critical_stale+="$source "
+                    fi
+                done
+                
+                if [[ -n "$critical_stale" ]]; then
+                    warn "⚠️  Beat API状态警告，关键数据延迟: $critical_stale"
+                    return 1
+                else
+                    warn "⚠️  Beat API状态警告（可选数据延迟）: $stale_data"
+                    return 0
+                fi
             else
                 error "Beat API状态异常: $api_status"
                 return 1


### PR DESCRIPTION
## Summary
- skip CMC market/kline freshness when features are disabled so beat health stops returning 503 for optional warnings
- make the monitor script treat the optional sources as soft warnings and only restart when core price data is stale

## Testing
- manual verification on deployed environment